### PR TITLE
Add basic AI training website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # testing
 for open AI cidex testing
+
+## AI Training Website
+This repository now includes a simple multi-page website in the `website/` folder. The site is written in Lithuanian and introduces our artificial intelligence training courses. Open `index.html` in a browser to explore the pages.

--- a/website/about.html
+++ b/website/about.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="lt">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Apie mus - DI Mokymai</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>Apie mus</h1>
+    </header>
+    <nav id="nav">
+        <ul>
+            <li><a href="index.html">Pradžia</a></li>
+            <li><a href="courses.html">Kursai</a></li>
+            <li><a href="about.html">Apie mus</a></li>
+            <li><a href="contact.html">Kontaktai</a></li>
+        </ul>
+    </nav>
+    <main>
+        <h2>Mūsų misija</h2>
+        <p>Siekiame suteikti aukščiausios kokybės dirbtinio intelekto mokymus tiek pradedantiesiems, tiek pažengusiems.</p>
+    </main>
+    <footer>
+        <p>&copy; 2025 DI Mokymai</p>
+    </footer>
+</body>
+</html>

--- a/website/contact.html
+++ b/website/contact.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="lt">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kontaktai - DI Mokymai</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>Kontaktai</h1>
+    </header>
+    <nav id="nav">
+        <ul>
+            <li><a href="index.html">Pradžia</a></li>
+            <li><a href="courses.html">Kursai</a></li>
+            <li><a href="about.html">Apie mus</a></li>
+            <li><a href="contact.html">Kontaktai</a></li>
+        </ul>
+    </nav>
+    <main>
+        <h2>Susisiekite</h2>
+        <p>El. paštas: <a href="mailto:info@dimokymai.lt">info@dimokymai.lt</a></p>
+        <p>Tel.: +370 600 00000</p>
+    </main>
+    <footer>
+        <p>&copy; 2025 DI Mokymai</p>
+    </footer>
+</body>
+</html>

--- a/website/courses.html
+++ b/website/courses.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="lt">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kursai - DI Mokymai</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <header>
+        <h1>Mūsų Kursai</h1>
+    </header>
+    <nav id="nav">
+        <ul>
+            <li><a href="index.html">Pradžia</a></li>
+            <li><a href="courses.html">Kursai</a></li>
+            <li><a href="about.html">Apie mus</a></li>
+            <li><a href="contact.html">Kontaktai</a></li>
+        </ul>
+    </nav>
+    <main>
+        <h2>Kursų sąrašas</h2>
+        <ul>
+            <li>Įvadas į dirbtinį intelektą</li>
+            <li>Mašininis mokymasis pradedantiesiems</li>
+            <li>Giliojo mokymosi pagrindai</li>
+            <li>Neprižiūrimas mokymas ir klasterizacija</li>
+        </ul>
+    </main>
+    <footer>
+        <p>&copy; 2025 DI Mokymai</p>
+    </footer>
+</body>
+</html>

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1,0 +1,8 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header { background: #222; color: white; padding: 1em; text-align: center; }
+nav ul { list-style-type: none; margin: 0; padding: 0; overflow: hidden; background-color: #333; }
+nav li { float: left; }
+nav li a { display: block; color: white; text-align: center; padding: 14px 16px; text-decoration: none; }
+nav li a:hover { background-color: #111; }
+main { padding: 1em; }
+footer { background: #f2f2f2; text-align: center; padding: 1em; margin-top: 2em; }

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="lt">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dirbtinio Intelekto Mokymai</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="js/main.js" defer></script>
+</head>
+<body>
+    <header>
+        <h1>Dirbtinio Intelekto Mokymai</h1>
+    </header>
+    <nav id="nav">
+        <ul>
+            <li><a href="index.html">Pradžia</a></li>
+            <li><a href="courses.html">Kursai</a></li>
+            <li><a href="about.html">Apie mus</a></li>
+            <li><a href="contact.html">Kontaktai</a></li>
+        </ul>
+    </nav>
+    <main>
+        <h2>Sveiki atvykę!</h2>
+        <p>Šioje svetainėje rasite informaciją apie mūsų siūlomus dirbtinio intelekto mokymus.</p>
+    </main>
+    <footer>
+        <p>&copy; 2025 DI Mokymai</p>
+    </footer>
+</body>
+</html>

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -1,0 +1,8 @@
+function toggleMenu() {
+  var nav = document.getElementById('nav');
+  if (nav.className === 'responsive') {
+    nav.className = '';
+  } else {
+    nav.className = 'responsive';
+  }
+}


### PR DESCRIPTION
## Summary
- add Lithuanian website about artificial intelligence training with multiple pages
- update README with website info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400c79e9f4832f932e403eecce044c