### PR TITLE
Add modern dark-themed landing page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,181 @@
-body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
-header { background: #222; color: white; padding: 1em; text-align: center; }
-nav ul { list-style-type: none; margin: 0; padding: 0; overflow: hidden; background-color: #333; }
-nav li { float: left; }
-nav li a { display: block; color: white; text-align: center; padding: 14px 16px; text-decoration: none; }
-nav li a:hover { background-color: #111; }
-main { padding: 1em; }
-footer { background: #f2f2f2; text-align: center; padding: 1em; margin-top: 2em; }
+:root {
+  --accent: #FF5C00;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #000;
+  color: #fff;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  background: #000;
+  z-index: 1000;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+}
+
+.logo {
+  font-weight: bold;
+  color: var(--accent);
+  font-size: 1.4rem;
+  letter-spacing: 1px;
+}
+
+.menu {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.menu a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  position: relative;
+}
+
+.menu a.active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 100%;
+  height: 2px;
+  background: var(--accent);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.btn {
+  background: var(--accent);
+  color: #000;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.btn:hover {
+  opacity: 0.8;
+}
+
+.hero {
+  text-align: center;
+  padding: 6rem 1rem;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+  padding: 4rem 2rem;
+}
+
+.card {
+  background: #111;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  transition: transform 0.3s;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+}
+
+.card img {
+  width: 100%;
+  height: auto;
+  margin-bottom: 1rem;
+}
+
+footer {
+  background: #111;
+  padding: 2rem;
+  text-align: center;
+}
+
+.footer-top {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.newsletter input {
+  padding: 0.5rem;
+  border: none;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+}
+
+.newsletter button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #000;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .menu {
+    display: none;
+    flex-direction: column;
+    background: #000;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    padding: 1rem 2rem;
+  }
+
+  .menu.show {
+    display: flex;
+  }
+
+  .menu-toggle {
+    display: block;
+    cursor: pointer;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+.animate {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.6s ease;
+}
+
+.animate.visible {
+  opacity: 1;
+  transform: none;
+}

--- a/img/ai1.svg
+++ b/img/ai1.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#FF5C00;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#FF0000;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <path d="M120 10 C70 20, 60 40, 60 100 C60 160, 70 180, 120 190" fill="url(#grad1)" />
+</svg>

--- a/img/ai2.svg
+++ b/img/ai2.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#FF5C00;stop-opacity:1"/>
+      <stop offset="50%" style="stop-color:#00FFD5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0051FF;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <circle cx="100" cy="100" r="80" fill="url(#grad2)" />
+  <circle cx="70" cy="80" r="10" fill="#111"/>
+  <circle cx="130" cy="80" r="10" fill="#111"/>
+  <path d="M70 130 Q100 150 130 130" stroke="#111" stroke-width="8" fill="none" stroke-linecap="round"/>
+</svg>

--- a/img/ai3.svg
+++ b/img/ai3.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#00AAFF;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#FF5C00;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="100" fill="url(#grad3)" />
+  <rect x="50" y="80" width="40" height="20" fill="none" stroke="#fff" stroke-width="4"/>
+  <rect x="110" y="80" width="40" height="20" fill="none" stroke="#fff" stroke-width="4"/>
+  <line x1="90" y1="90" x2="110" y2="90" stroke="#fff" stroke-width="4"/>
+  <circle cx="150" cy="150" r="20" fill="none" stroke="#fff" stroke-width="6"/>
+  <line x1="150" y1="150" x2="160" y2="160" stroke="#fff" stroke-width="6"/>
+  <line x1="150" y1="150" x2="140" y2="160" stroke="#fff" stroke-width="6"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,30 +1,81 @@
 <!DOCTYPE html>
 <html lang="lt">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dirbtinio Intelekto Mokymai</title>
-    <link rel="stylesheet" href="css/style.css">
-    <script src="js/main.js" defer></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Praktiniai dirbtinio intelekto mokymai</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script src="js/main.js" defer></script>
 </head>
 <body>
-    <header>
-        <h1>Dirbtinio Intelekto Mokymai</h1>
-    </header>
-    <nav id="nav">
-        <ul>
-            <li><a href="index.html">Pradžia</a></li>
-            <li><a href="courses.html">Kursai</a></li>
-            <li><a href="about.html">Apie mus</a></li>
-            <li><a href="contact.html">Kontaktai</a></li>
-        </ul>
+<header>
+  <div class="navbar">
+    <div class="logo">WHY AI</div>
+    <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+    <nav id="menu" class="menu">
+      <a href="#apie">Apie</a>
+      <a href="#mokymai" class="active">Mokymai</a>
+      <a href="#bendruomene">Bendruomenė</a>
+      <a href="#parduotuve">Parduotuvė</a>
+      <a href="#blogas">Blogas</a>
     </nav>
-    <main>
-        <h2>Sveiki atvykę!</h2>
-        <p>Šioje svetainėje rasite informaciją apie mūsų siūlomus dirbtinio intelekto mokymus.</p>
-    </main>
-    <footer>
-        <p>&copy; 2025 DI Mokymai</p>
-    </footer>
+    <div class="actions">
+      <a href="#" class="lang-switch">EN</a>
+      <span class="cart">🛒</span>
+      <a href="#konsultacija" class="btn">KONSULTACIJA</a>
+    </div>
+  </div>
+</header>
+
+<section class="hero animate">
+  <h1>Praktiniai dirbtinio intelekto mokymai</h1>
+  <p>Sužinokite, kaip AI keičia pasaulį ir jūsų įgūdžius.</p>
+</section>
+
+<section class="grid animate" id="mokymai">
+  <div class="card">
+    <img src="img/ai1.svg" alt="AI art portrait">
+    <h3>AI mokymai – įvadas į pagrindus</h3>
+    <p>Praktinės AI žinios ir geriausi šablonai.</p>
+    <ul>
+      <li>20 realių AI pritaikymo sričių.</li>
+      <li>Naujausios technologijų tendencijos.</li>
+    </ul>
+  </div>
+  <div class="card">
+    <img src="img/ai2.svg" alt="AI workshop">
+    <h3>AI mokymai – personalizuotos dirbtuvės</h3>
+    <ul>
+      <li>Asmeniškai pritaikytas turinys.</li>
+      <li>95 % mokymų – realūs pavyzdžiai ir užduotys.</li>
+    </ul>
+  </div>
+  <div class="card">
+    <img src="img/ai3.svg" alt="AI hakatonas">
+    <h3>AI hakatonas verslams ir įmonėms</h3>
+    <ul>
+      <li>AI sprendimai rinkodarai, pardavimams, HR.</li>
+      <li>Praktika – AI integracija į verslo procesus.</li>
+      <li>Šablonai, konsultacijos, naujausias turinys.</li>
+    </ul>
+  </div>
+</section>
+
+<section class="animate" id="konsultacija" style="text-align:center;padding:3rem 1rem;">
+  <a href="#" class="btn">KONSULTACIJA</a>
+</section>
+
+<footer>
+  <div class="footer-top">
+    <div>Kontaktai<br>info@dimokymai.lt</div>
+    <div>Nuorodos<br>Apie | Mokymai | Bendruomenė</div>
+    <div class="newsletter">
+      Naujienlaiškis<br>
+      <input type="email" placeholder="El. paštas">
+      <button>Siųsti</button>
+    </div>
+  </div>
+  <div>&copy; 2025 WHY AI</div>
+</footer>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,16 @@
 function toggleMenu() {
-  var nav = document.getElementById('nav');
-  if (nav.className === 'responsive') {
-    nav.className = '';
-  } else {
-    nav.className = 'responsive';
-  }
+  const menu = document.getElementById('menu');
+  menu.classList.toggle('show');
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+      }
+    });
+  }, { threshold: 0.2 });
+
+  document.querySelectorAll('.animate').forEach(el => observer.observe(el));
+});


### PR DESCRIPTION
## Summary
- redesign index with dark theme, sticky navbar and hero section
- add AI themed grid section with orange accent
- create minimal AI portrait SVGs
- style the site with modern responsive CSS and animations
- update JS for mobile menu and section reveal

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404d1eb578832fabe5bea407f9f128